### PR TITLE
iojs version constraint (1.2.0) to make node-sass build pass during npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,13 @@ users(done) {
 
 I recommend to use [io.js](https://iojs.org/) to take advantages of `ES6` without `--harmony` flag on `NodeJS`.
 
+**Note:** We're using [io.js](https://iojs.org/) **1.2.0**. `node-sass` (`gulp-sass` dependency) **does not yet support io.js > 1.2.0**. See [#699](https://github.com/sass/node-sass/issues/699)
+
 It's super easy to do with [nvm](https://github.com/creationix/nvm):
 
-* `$ nvm install iojs`
-* `$ nvm use iojs`
-* `$ nvm alias default iojs` (to make `node` default to `iojs`)
+* `$ nvm install iojs-v1.2.0`
+* `$ nvm use iojs-v1.2.0`
+* `$ nvm alias default iojs-v1.2.0` (to make `node` default to `iojs-v1.2.0`)
 
 After that, you will just need to clone the repo and install dependancies:
 

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "webpack",
     "jsx",
     "es6"
-  ]
+  ],
+  "engines": {
+    "iojs": "1.2.0"
+  }
 }


### PR DESCRIPTION
Hi,

Cool project man!

I had trouble installing it from scratch with node-sass build failing during `npm install`.

I found that `node-sass` does not support `io.js` > 1.2.0 and I was using 1.3.0.
Everything worked fine after downgrading to `io.js` 1.2.0.
See [#699](https://github.com/sass/node-sass/issues/699)

I've updated:

* `README` to specify `io.js` version constraint.
* `package.json` to include io.js version in **"engines"** field.
