### PR TITLE
refactor: use alt-resolver as class

### DIFF
--- a/app/actions/users.js
+++ b/app/actions/users.js
@@ -2,7 +2,6 @@
 
 import {sample, take} from 'lodash';
 
-import altResolver from 'utils/alt-resolver';
 import data from 'data/users.json';
 
 class UsersActions {
@@ -22,7 +21,7 @@ class UsersActions {
         return resolve();
       }, 300);
     };
-    altResolver.resolve(promise);
+    this.alt.resolve(promise);
   }
   fetch() {
     const promise: Function = (resolve) => {
@@ -33,7 +32,7 @@ class UsersActions {
         return resolve();
       }, 300);
     };
-    altResolver.resolve(promise);
+    this.alt.resolve(promise);
   }
   fetchBySeed(seed: string) {
     const promise = (resolve) => {
@@ -45,7 +44,8 @@ class UsersActions {
         return resolve();
       }, 300);
     };
-    altResolver.resolve(promise);
+
+    this.alt.resolve(promise);
   }
 }
 

--- a/app/utils/alt-resolver.js
+++ b/app/utils/alt-resolver.js
@@ -6,23 +6,24 @@ import debug from 'debug';
 
 import ErrorPage from 'pages/server-error';
 
-const toResolve = [];
-
-export default {
+export default class AltResolver {
+  constructor() {
+    this._toResolve = [];
+  }
   resolve(promise: Function, later = false) {
     if (process.env.BROWSER && !later) {
       return new Promise(promise);
     }
     else {
-      toResolve.push(promise);
+      this._toResolve.push(promise);
     }
-  },
+  }
   mapPromises() {
-    return toResolve.map((promise) => new Promise(promise));
-  },
+    return this._toResolve.map((promise) => new Promise(promise));
+  }
   cleanPromises() {
-    toResolve.length = 0;
-  },
+    this._toResolve.length = 0;
+  }
   async render(Handler: object, flux: object, force: ?boolean = false) {
     if (process.env.BROWSER && !force) {
       debug('dev')('`altResolver.render` should not be used in browser, something went wrong');
@@ -68,4 +69,4 @@ export default {
       return content;
     }
   }
-};
+}

--- a/app/utils/flux.js
+++ b/app/utils/flux.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import Alt from 'alt';
+import AltResolver from './alt-resolver.js';
 
 import RequestsActions from 'actions/requests';
 import LocaleActions from 'actions/locale';
@@ -15,6 +16,8 @@ class Flux extends Alt {
   constructor(config = {}) {
     super(config);
 
+    this._resolver = new AltResolver();
+
     // Register Actions
     this.addActions('requests', RequestsActions);
     this.addActions('locale', LocaleActions);
@@ -26,6 +29,13 @@ class Flux extends Alt {
     this.addStore('users', UsersStore);
   }
 
+  resolve(result) {
+    this._resolver.resolve(result);
+  }
+
+  render(handler) {
+    return this._resolver.render(handler, this);
+  }
 }
 
 export default Flux;

--- a/server/router.jsx
+++ b/server/router.jsx
@@ -9,7 +9,6 @@ import Router from 'react-router';
 // Paths are relative to `app` directory
 import routes from 'routes';
 import Flux from 'utils/flux';
-import altResolver from 'utils/alt-resolver';
 import promisify from 'utils/promisify';
 
 export default function *() {
@@ -45,7 +44,7 @@ export default function *() {
     debug('dev')(`locale of request: ${locale}`);
 
     const handler = yield promisify(router.run);
-    const content = yield altResolver.render(handler, flux);
+    const content = yield flux.render(handler);
 
     // Reload './webpack-stats.json' on dev
     // cache it on production

--- a/test/spec/utils/alt-resolver.test.js
+++ b/test/spec/utils/alt-resolver.test.js
@@ -3,7 +3,7 @@
 import chai from 'chai';
 import React from 'react';
 import Flux from 'utils/flux';
-import altResolver from 'utils/alt-resolver';
+import AltResolver from 'utils/alt-resolver';
 
 import injectLang from '../../utils/inject-lang';
 
@@ -24,9 +24,11 @@ const DummyError = React.createClass({
 describe('Alt Resolver', () => {
 
   let flux;
+  let altResolver;
 
   before(() => {
     flux = new Flux();
+    altResolver = new AltResolver();
     injectLang(flux);
   });
 


### PR DESCRIPTION
Use alt-resolver as class.
This solves #28 as a side product, and looks a bit cleaner in my perspective.
Plus, I think cleanPromises is now not really needed, am I correct?