### PR TITLE
update autoprefixer-loader to 2.0.0 major relase

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "superagent": "^1.1.0"
   },
   "devDependencies": {
-    "autoprefixer-loader": "^1.2.0",
+    "autoprefixer-loader": "^2.0.0",
     "babel": "^5.1.8",
     "babel-core": "^5.1.8",
     "babel-eslint": "^3.0.0",


### PR DESCRIPTION
Recently there is a warning in the console `Autoprefixer's process() method is deprecated and will removed in next major release. Use postcss([autoprefixer]).process() instead` updating `autoprefixer-loader` simply solves this stuff.