### PR TITLE
Fixed issue where Iso HTML & State would be out-of-sync

### DIFF
--- a/app/utils/alt-resolver.js
+++ b/app/utils/alt-resolver.js
@@ -49,21 +49,24 @@ class AltResolver {
 
       debug('dev')('second render');
       // Get the new content with promises resolved
+
+      const fluxSnapshot = flux.takeSnapshot();
       const app = React.renderToString(Handler);
       const {title} = flux.getStore('page-title').getState();
 
       // Render the html with state in it
-      content = {body: Iso.render(app, flux.flush()), title};
+      content = {body: Iso.render(app, fluxSnapshot), title};
     }
     catch (error) {
       // catch script error, render 500 page
       debug('koa')('`rendering error`');
       debug('koa')(error);
 
+      const fluxSnapshot = flux.takeSnapshot();
       const app = React.renderToString(React.createElement(ErrorPage));
       const {title} = flux.getStore('page-title').getState();
 
-      content = {body: Iso.render(app, flux.flush()), title};
+      content = {body: Iso.render(app, fluxSnapshot), title};
     }
 
     // return the content


### PR DESCRIPTION
This took me a while to figure out! I hope the fix makes sense.

It should address a problem where the HTML and state that are passed to Iso would not match up, as the two are collected at ever so slightly different points in time. This was brought to my attention by the console warning that React gives when the markup it renders initially in the browser does not match up with the server-rendered markup.

I had a component with an `inProgress` boolean as part of its state. This would of course change depending on when `onFetchStart` and `onFetchSuccess`/`onFetchFail` actions are dispatched. I could not understand why the Iso HTML markup reflected that `inProgress` was `false`, while the Iso state object showed that `inProgress` was `true`. As it turns out it was due to the way `alt-renderer` uses `flux.flush()` *after* the second `React.renderToString`.

My thinking is that because all XHR promises will have been resolved on the first render, a snapshot of the Alt state can be taken after all promises have been resolved, and immediately before running the second `React.renderToString`.