### PR TITLE
Update package.json to point to latest `karma-webpack`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "karma-firefox-launcher": "^0.1.6",
     "karma-mocha": "^0.2.0",
     "karma-sourcemap-loader": "^0.3.5",
-    "karma-webpack": "dignifiedquire/karma-webpack#29fb1d801158f29cb0eb784edff69356705a7b74",
+    "karma-webpack": "^1.7.0",
     "mocha": "^2.2.5",
     "node-watch": "^0.3.4",
     "postcss-loader": "^0.5.1",


### PR DESCRIPTION
Use latest `karma-webpack` since the specific commit it was pointing before didn't exist/would error on `npm install`.

See #98 