### PR TITLE
fix badly formatted url for cssnext in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 * [koa](http://koajs.com/)
 * [webpack](http://webpack.github.io/)
 * [babeljs](https://babeljs.io/)
-* [cssnext](http://http://cssnext.io/)
+* [cssnext](http://cssnext.io/)
 
 ## TL;DR
 


### PR DESCRIPTION
README.md has a double `http://` for the URL for cssnext, not a big deal but figured I'd fix it. :)