### PR TITLE
rethrow the caught error

### DIFF
--- a/server/router.jsx
+++ b/server/router.jsx
@@ -44,6 +44,6 @@ export default function *() {
       return this.redirect(pathname + search);
     }
 
-    throw error;
+    throw err;
   }
 }


### PR DESCRIPTION
by the time of this throw "error" is known to be falsy so it's better to re-throw the caught error "err".  This bug was eating errors and making it very difficult to debug.