### PR TITLE
allow auth on server side

### DIFF
--- a/app/flux/actions/session.js
+++ b/app/flux/actions/session.js
@@ -1,7 +1,7 @@
 class SessionActions {
 
   constructor() {
-    this.generateActions('login', 'logout');
+    this.generateActions('login', 'logout', 'update');
   }
 
 }

--- a/app/flux/stores/session.js
+++ b/app/flux/stores/session.js
@@ -9,6 +9,10 @@ class SessionStore {
     this.session = null;
   }
 
+  onUpdate({ username }) {
+    this.session = { username };
+  }
+
   onLogin({ username }) {
     this.session = { username };
 
@@ -19,6 +23,9 @@ class SessionStore {
       const [, nextPath = '/account' ] = window
         .location.search.match(/\?redirect=(.+)$/) || [];
 
+      const Cookies = require('cookies-js');
+      Cookies.set('_auth', username);
+
       debug('dev')('redirect after login to %s', nextPath);
       return history.replaceState(null, nextPath);
     }
@@ -26,7 +33,11 @@ class SessionStore {
 
   onLogout() {
     this.session = null;
-    if (BROWSER) require('utils/router-history').replaceState(null, '/login');
+    if (BROWSER) {
+      const Cookies = require('cookies-js');
+      Cookies.expire('_auth');
+      require('utils/router-history').replaceState(null, '/login');
+    }
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "extract-text-webpack-plugin": "^0.9.1",
     "file-loader": "^0.8.4",
     "font-awesome": "^4.4.0",
-    "history": "^1.9.1",
+    "history": "~1.13.x",
     "image-webpack-loader": "^1.6.2",
     "intl": "^1.0.0",
     "iso": "^4.1.0",

--- a/server/router.jsx
+++ b/server/router.jsx
@@ -18,10 +18,20 @@ export default function *() {
   const locale = this.cookies.get('_lang') || this.acceptsLanguages(require('./config/init').locales) || 'en';
   const { messages } = require(`data/${locale}`);
 
+  // Get auth-token from cookie
+  const username = this.cookies.get('_auth');
+
   // Populate store with locale
   flux
     .getActions('locale')
     .switchLocaleSuccess({ locale, messages });
+
+  // Populate store with auth
+  if (username) {
+      flux
+        .getActions('session')
+        .update({ username });
+  }
 
   debug('dev')(`locale of request: ${locale}`);
 


### PR DESCRIPTION
Thanks provide #161 for authorization. But if login successful and redirect to /account, then reload /account will cause a unauthorized process and redirect to /login. So fix this issue by adding auth token in cookie and populate to session store on server side