### PR TITLE
Correct misspelling of key in webpack config

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -38,7 +38,7 @@ export default {
         './app/index.js'
       ]
     },
-    ouput: { ...baseConfig.output, publicPath: PUBLIC_PATH },
+    output: { ...baseConfig.output, publicPath: PUBLIC_PATH },
     module: {
       ...baseConfig.module,
       loaders: [


### PR DESCRIPTION
This corrects the spelling of the key 'output' in dev.config.js.