### PR TITLE
I18n through context

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,26 @@ There's also `alt-devtools` enabled in development, it's a Chrome Extension that
 
 ## Internationalization (i18n)
 
+The boilerplate provides an easy way to use internationalization, it provides through context a function called `i18n` that does not break when translations are missing. No more `react-intl/IntlMixin` to load everywhere.
+
+```javascript
+static contextTypes = { i18n: PropTypes.func.isRequired }
+
+render() {
+  const { i18n } = this.context;
+  return (
+    <div>
+      {/* You can pass values to `i18n` fn like `<FormattedMessage />` component */}
+      <h1>{ i18n('some.random.i18n.key', { now: new Date() }) }</h1>
+
+      {/* FormattedRelative, FormattedCurrency works out the box :+1: */}
+      <FormattedRelative value={Date.now() - (1000 * 60 * 60 * 24)} />
+    </div>
+  );
+}
+```
+
+
 We use [react-intl](https://github.com/yahoo/react-intl) for internationalization, it uses browser implementation of [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl). For older browser and for node, we load the polyfill.
 
 * Support localized strings (see [data/en.js](https://github.com/iam4x/isomorphic-flux-boilerplate/blob/master/app%2Fdata%2Fen.js))
@@ -73,23 +93,6 @@ Lang files and Intl polyfill are compiled into webpack chunks, for lazy-loading 
 If user changes locale, it is saved into a cookie `_lang` and used by the server to know the locale of rendering. If there's no `_lang` cookie, server will rely on `Accept-Language` request header. Server will set `<html lang='x'>` on rendering.
 
 Thank's to [gpbl/react-locale-hot-switch](https://github.com/gpbl/react-locale-hot-switch) for the implementation example!
-
-In order to use `FormattedRelative` you have to require `messages` && `locales` from context and pass them as props:
-
-```javascript
-static contextTypes = {
-  messages: PropTypes.object.isRequired,
-  locales: PropTypes.array.isRequired
-}
-
-render() {
-  return (
-    <FormattedRelative
-      { ...this.context }
-      value={Date.now() - (1000 * 60 * 60 * 24)} />
-  );
-}
-```
 
 ## Localized routes
 

--- a/app/components/app.jsx
+++ b/app/components/app.jsx
@@ -10,35 +10,17 @@ class App extends Component {
   static propTypes = { children: PropTypes.element }
   static contextTypes = { flux: PropTypes.object.isRequired }
 
-  static childContextTypes = {
-    messages: PropTypes.object.isRequired,
-    locales: PropTypes.array.isRequired
-  }
-
   state = { i18n: this.context
       .flux.getStore('locale').getState() }
 
-  getChildContext() {
-    const { i18n: { messages, locales } } = this.state;
-    return { messages, locales };
-  }
-
   componentDidMount() {
     const { flux } = this.context;
-
-    flux.getStore('locale').listen(this.handleLocaleChange);
     flux.getStore('helmet').listen(this.handleTitleChange);
   }
 
   componentWillUnmount() {
     const { flux } = this.context;
-
-    flux.getStore('locale').unlisten(this.handleLocaleChange);
     flux.getStore('helmet').unlisten(this.handleTitleChange);
-  }
-
-  handleLocaleChange = (i18n) => {
-    this.setState({ i18n });
   }
 
   handleTitleChange({ titleBase, title }) {

--- a/app/components/guides.jsx
+++ b/app/components/guides.jsx
@@ -1,19 +1,17 @@
 import React, { Component, PropTypes } from 'react';
-import { IntlMixin } from 'react-intl';
 
 class Guides extends Component {
 
   static contextTypes = {
     flux: PropTypes.object.isRequired,
-    messages: PropTypes.object.isRequired
+    i18n: PropTypes.func.isRequired
   }
 
-  i18n = IntlMixin.getIntlMessage
-
   componentWillMount() {
-    const { flux } = this.context;
-    flux.getActions('helmet')
-      .update({ title: this.i18n('guides.page-title') });
+    const { flux, i18n } = this.context;
+
+    return flux.getActions('helmet')
+      .update({ title: i18n('guides.page-title') });
   }
 
   render() {

--- a/app/components/header.jsx
+++ b/app/components/header.jsx
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import connect from 'connect-alt';
 import { Link } from 'react-router';
-import { IntlMixin } from 'react-intl';
 
 import imageResolver from 'utils/image-resolver';
 import Spinner from 'components/shared/spinner';
@@ -28,11 +27,9 @@ class Header extends Component {
 
   static contextTypes = {
     locales: PropTypes.array.isRequired,
-    messages: PropTypes.object.isRequired,
-    flux: PropTypes.object.isRequired
+    flux: PropTypes.object.isRequired,
+    i18n: PropTypes.func.isRequired
   }
-
-  i18n = IntlMixin.getIntlMessage
 
   handleLocaleChange(locale) {
     const { flux } = this.context;
@@ -46,7 +43,7 @@ class Header extends Component {
 
   render() {
     const { inProgress, session } = this.props;
-    const { locales: [ activeLocale ] } = this.context;
+    const { locales: [ activeLocale ], i18n } = this.context;
 
     return (
       <header className='app--header'>
@@ -66,31 +63,31 @@ class Header extends Component {
         {/* Links in the navbar */}
         <ul className='app--navbar text-center reset-list un-select'>
           <li>
-            <Link to={ this.i18n('routes.users') }>
-              { this.i18n('header.users') }
+            <Link to={ i18n('routes.users') }>
+              { i18n('header.users') }
             </Link>
           </li>
           <li>
-            <Link to={ this.i18n('routes.guides') }>
-              { this.i18n('header.guides') }
+            <Link to={ i18n('routes.guides') }>
+              { i18n('header.guides') }
             </Link>
           </li>
           { session ?
             [
               <li key={ 0 }>
-                <Link to={ this.i18n('routes.account') }>
-                  { this.i18n('header.account') }
+                <Link to={ i18n('routes.account') }>
+                  { i18n('header.account') }
                 </Link>
               </li>,
               <li key={ 1 }>
                 <a href='#' onClick={ ::this.handleLogout }>
-                  { this.i18n('header.logout') }
+                  { i18n('header.logout') }
                 </a>
               </li>
             ] :
             <li>
-              <Link to={ this.i18n('routes.login') }>
-                { this.i18n('header.login') }
+              <Link to={ i18n('routes.login') }>
+                { i18n('header.login') }
               </Link>
             </li>
           }

--- a/app/components/profile.jsx
+++ b/app/components/profile.jsx
@@ -3,23 +3,19 @@ import defer from 'lodash/function/defer';
 
 import React, { Component, PropTypes } from 'react';
 import connect from 'connect-alt';
-import { IntlMixin } from 'react-intl';
 
 @connect(({ users: { collection } }) => ({ collection }))
 class Profile extends Component {
 
   static contextTypes = {
     flux: PropTypes.object.isRequired,
-    messages: PropTypes.object.isRequired
+    i18n: PropTypes.func.isRequired
   }
 
   static propTypes = {
     params: PropTypes.object.isRequired,
     collection: PropTypes.array
   }
-
-  i18n = IntlMixin.getIntlMessage
-  formatMessage = IntlMixin.formatMessage.bind({ ...this, ...IntlMixin })
 
   componentWillMount() {
     const { flux } = this.context;
@@ -42,7 +38,7 @@ class Profile extends Component {
   }
 
   updatePageTitle() {
-    const { flux } = this.context;
+    const { flux, i18n } = this.context;
     const user = this.getUser();
 
     let title;
@@ -50,10 +46,9 @@ class Profile extends Component {
       const { name: { first, last } } = user;
       const fullName = `${capitalize(first)} ${capitalize(last)}`;
 
-      title = this.i18n('profile.page-title');
-      title = this.formatMessage(title, { fullName });
+      title = i18n('profile.page-title', { fullName });
     } else {
-      title = this.i18n('profile.not-found-page-title');
+      title = i18n('profile.not-found-page-title');
     }
 
     flux.getActions('helmet').update({ title });

--- a/app/components/users.jsx
+++ b/app/components/users.jsx
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import connect from 'connect-alt';
 import { Link } from 'react-router';
-import { IntlMixin } from 'react-intl';
 
 import { replaceParams } from 'utils/localized-routes';
 
@@ -12,15 +11,13 @@ class Users extends Component {
 
   static contextTypes = {
     flux: PropTypes.object.isRequired,
-    messages: PropTypes.object.isRequired
+    i18n: PropTypes.func.isRequired
   }
 
-  i18n = IntlMixin.getIntlMessage
-
   componentWillMount() {
-    const { flux } = this.context;
+    const { flux, i18n } = this.context;
 
-    flux.getActions('helmet').update({ title: this.i18n('users.page-title') });
+    flux.getActions('helmet').update({ title: i18n('users.page-title') });
     flux.getActions('users').index();
   }
 
@@ -30,8 +27,9 @@ class Users extends Component {
   }
 
   renderUser = (user, index) => {
+    const { i18n } = this.context;
     const profileRoute = replaceParams(
-      this.i18n('routes.profile'),
+      i18n('routes.profile'),
       { seed: user.seed }
     );
 
@@ -39,7 +37,7 @@ class Users extends Component {
       <tr className='user--row' key={ index }>
         <td>{ user.email }</td>
         <td className='text-center'>
-          <Link to={ profileRoute }>{ this.i18n('users.profile') }</Link>
+          <Link to={ profileRoute }>{ i18n('users.profile') }</Link>
         </td>
         <td className='text-center'>
           <button
@@ -54,17 +52,18 @@ class Users extends Component {
 
   render() {
     const { collection } = this.props;
+    const { i18n } = this.context;
 
     return (
       <div>
         <h1 className='text-center'>
-          { this.i18n('users.title') }
+          { i18n('users.title') }
         </h1>
         <table className='app--users'>
           <thead>
             <tr>
-              <th> { this.i18n('users.email') } </th>
-              <th colSpan='2'> { this.i18n('users.actions') } </th>
+              <th> { i18n('users.email') } </th>
+              <th colSpan='2'> { i18n('users.actions') } </th>
             </tr>
           </thead>
           <tbody>

--- a/app/flux/stores/locale.js
+++ b/app/flux/stores/locale.js
@@ -6,6 +6,7 @@ class LocaleStore {
     this.bindActions(this.alt.getActions('locale'));
     this.locales = [];
     this.messages = {};
+    this.formats = {};
   }
 
   onSwitchLocale({ messages, locale }) {

--- a/app/pages/login.jsx
+++ b/app/pages/login.jsx
@@ -1,14 +1,11 @@
 import React, { Component, PropTypes } from 'react';
-import { IntlMixin } from 'react-intl';
 
 class LoginPage extends Component {
 
   static contextTypes = {
     flux: PropTypes.object.isRequired,
-    messages: PropTypes.object.isRequired
+    i18n: PropTypes.func.isRequired
   }
-
-  i18n = IntlMixin.getIntlMessage
 
   handleSubmit(e) {
     e.preventDefault();
@@ -22,24 +19,26 @@ class LoginPage extends Component {
   }
 
   render() {
+    const { i18n } = this.context;
+
     return (
       <form onSubmit={ ::this.handleSubmit }>
-        <p className='alert alert-info'>{ this.i18n('login.help') }</p>
+        <p className='alert alert-info'>{ i18n('login.help') }</p>
         <div className='form-group'>
           <label htmlFor='username'>
-            { this.i18n('login.username.label') }
+            { i18n('login.username.label') }
           </label>
           <input
             ref='username'
             type='text'
             name='username'
             className='form-control'
-            placeholder={ this.i18n('login.username.placeholder') }
+            placeholder={ i18n('login.username.placeholder') }
             required />
         </div>
         <div className='form-group'>
           <label htmlFor='username'>
-            { this.i18n('login.password.label') }
+            { i18n('login.password.label') }
           </label>
           <input
             ref='password'
@@ -50,7 +49,7 @@ class LoginPage extends Component {
         </div>
         <div className='form-group'>
           <button className='btn btn-primary'>
-            { this.i18n('login.submit') }
+            { i18n('login.submit') }
           </button>
         </div>
       </form>

--- a/app/utils/i18n-container.jsx
+++ b/app/utils/i18n-container.jsx
@@ -1,0 +1,64 @@
+import debug from 'debug';
+
+import { Component, PropTypes } from 'react';
+import { IntlMixin } from 'react-intl';
+
+class I18nContainer extends Component {
+
+  static propTypes = { children: PropTypes.element.isRequired }
+  static contextTypes = { flux: PropTypes.object.isRequired }
+
+  static childContextTypes = {
+    i18n: PropTypes.func.isRequired,
+    messages: PropTypes.object.isRequired,
+    formats: PropTypes.object.isRequired,
+    locales: PropTypes.array.isRequired
+  }
+
+  constructor(props, context) {
+    super(props, context);
+
+    const { flux } = this.context;
+    this.state = flux.getStore('locale').getState();
+  }
+
+  getChildContext() {
+    return { ...this.state, i18n: this.i18n };
+  }
+
+  componentDidMount() {
+    const { flux } = this.context;
+    flux.getStore('locale').listen(this.handleLocaleChange);
+  }
+
+  componentWillUnmount() {
+    const { flux } = this.context;
+    flux.getStore('locale').unlisten(this.handleLocaleChange);
+  }
+
+  handleLocaleChange = (state) => {
+    return this.setState(state);
+  }
+
+  i18n = (key, values) => {
+    try {
+      // Fake IntlMixin context with `messages`, `formats` and `locales`
+      // into `this.props` and `this.context`
+      const ctx = { ...IntlMixin, context: this.state, props: this.state };
+
+      const messages = IntlMixin.getIntlMessage.call(ctx, key);
+      return IntlMixin.formatMessage.call(ctx, messages, values);
+    } catch (error) {
+      debug('dev')(error);
+      return `translation missing (${this.state.locales[0]}): ${key}`;
+    }
+  }
+
+  render() {
+    const { children } = this.props;
+    return children;
+  }
+
+}
+
+export default I18nContainer;

--- a/app/utils/intl-loader.js
+++ b/app/utils/intl-loader.js
@@ -50,7 +50,11 @@ export default (locale, force) => {
       // We need to define `ReactIntl` on the global scope
       // in order to load specific locale data from `ReactIntl`
       // see: https://github.com/iam4x/isomorphic-flux-boilerplate/issues/64
-      if (process.env.BROWSER) window.ReactIntl = require('react-intl');
+      if (process.env.BROWSER) {
+        window.ReactIntl = require('react-intl');
+        require(`react-intl/dist/locale-data/${locale}.js`);
+      }
+
       return resolve(result);
     }, force);
   });

--- a/shared/universal-render.jsx
+++ b/shared/universal-render.jsx
@@ -10,6 +10,7 @@ import AltContainer from 'alt-container';
 
 import intlLoader from 'utils/intl-loader';
 import ErrorPage from 'pages/server-error';
+import I18nContainer from 'utils/i18n-container';
 
 const { BROWSER, NODE_ENV } = process.env;
 
@@ -41,9 +42,11 @@ export default async function({ flux, history, location }) {
 
     const element = (
       <AltContainer flux={ flux }>
-        <Router
-          history={ history }
-          routes={ routes(flux) } />
+        <I18nContainer>
+          <Router
+            history={ history }
+            routes={ routes(flux) } />
+        </I18nContainer>
       </AltContainer>
     );
 
@@ -61,7 +64,9 @@ export default async function({ flux, history, location }) {
 
     const element = (
       <AltContainer flux={ flux }>
-        <RoutingContext { ...renderProps } />
+        <I18nContainer>
+          <RoutingContext { ...renderProps } />
+        </I18nContainer>
       </AltContainer>
     );
 

--- a/test/utils/stub-app.jsx
+++ b/test/utils/stub-app.jsx
@@ -1,50 +1,32 @@
 /* eslint react/display-name: 0 */
 import React, { Component, PropTypes } from 'react';
+import I18nContainer from 'utils/i18n-container';
 
-export default function stubApp(flux, stubs) {
+export default function stubApp(flux) {
   const { messages } = require('data/en');
 
   flux
     .getActions('locale')
     .switchLocale({ locale: 'en', messages });
 
-  const i18n = flux.getStore('locale').getState();
-
-  const router = {
-    makePath() {},
-    makeHref() {},
-    transitionTo() {},
-    replaceWith() {},
-    goBack() {},
-    getCurrentPath() {},
-    getCurrentRoutes() {},
-    getCurrentPathname() {},
-    getCurrentParams() {},
-    getCurrentQuery() {},
-    isActive() {},
-    getRouteAtDepth() {},
-    setRouteComponentAtDepth() {},
-    ...stubs
-  };
-
   return function (DecoratedComponent, props) {
     return class Wrapper extends Component {
 
       static childContextTypes = {
-        flux: PropTypes.object.isRequired,
-        messages: PropTypes.object.isRequired,
-        locales: PropTypes.array.isRequired,
-        router: PropTypes.object.isRequired,
-        routeDepth: PropTypes.number.isRequired
+        flux: PropTypes.object.isRequired
       }
 
       getChildContext() {
-        return { flux, router, routeDepth: 0, ...i18n };
+        return { flux };
       }
 
       render() {
         const customProps = { ...this.props, ...props };
-        return (<DecoratedComponent { ...customProps } />);
+        return (
+          <I18nContainer>
+            <DecoratedComponent { ...customProps } />
+          </I18nContainer>
+        );
       }
 
     };


### PR DESCRIPTION
Simplifies the usage of `react-intl` into components by providing an `i18n` function through context. 

(Fixes #189)