### PR TITLE
Load _variables.css before _fonts.css to properly load fonts

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,8 +1,8 @@
 @import 'normalize.css/normalize';
 @import 'font-awesome/css/font-awesome.css';
 
-@import './_fonts';
 @import './_variables';
+@import './_fonts';
 
 @import './footer';
 @import './header';


### PR DESCRIPTION
If the files aren't imported correctly, the variables are undefined and no fonts get loaded.